### PR TITLE
Add log context for DtlsServer

### DIFF
--- a/src/CoAPNet.Dtls/Server/CoapDtlsServerClientEndPoint.cs
+++ b/src/CoAPNet.Dtls/Server/CoapDtlsServerClientEndPoint.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -29,7 +30,7 @@ namespace CoAPNet.Dtls.Server
 
         public IPEndPoint EndPoint { get; }
         public Uri BaseUri { get; }
-        public string ConnectionInfo { get; private set; }
+        public IReadOnlyDictionary<string, object> ConnectionInfo { get; private set; }
 
         public bool IsSecure => true;
 

--- a/src/CoAPNet.Dtls/Server/IDtlsServerWithConnectionInfo.cs
+++ b/src/CoAPNet.Dtls/Server/IDtlsServerWithConnectionInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Org.BouncyCastle.Tls;
+using System.Collections.Generic;
 
 namespace CoAPNet.Dtls.Server
 {
@@ -12,6 +13,6 @@ namespace CoAPNet.Dtls.Server
         /// Get the connection information for the connection handled by this TLS server.
         /// </summary>
         /// <returns>Information about this connection that should be logged once the connection is established.</returns>
-        string GetConnectionInfo();
+        IReadOnlyDictionary<string, object> GetConnectionInfo();
     }
 }

--- a/src/CoAPNet.Dtls/Server/Statistics/DtlsSessionStatistics.cs
+++ b/src/CoAPNet.Dtls/Server/Statistics/DtlsSessionStatistics.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace CoAPNet.Dtls.Server.Statistics
 {
     public class DtlsSessionStatistics
     {
         public string EndPoint { get; set; }
-        public string ConnectionInfo { get; set; }
+        public IReadOnlyDictionary<string, object> ConnectionInfo { get; set; }
         public DateTime SessionStartTime { get; internal set; }
         public DateTime LastReceivedTime { get; internal set; }
     }


### PR DESCRIPTION
Add the option to let DtlsServer return context that is added to all log messages within the connection handler.