### PR TITLE
Connection id improvements

### DIFF
--- a/samples/DtlsClient/DtlsClient.csproj
+++ b/samples/DtlsClient/DtlsClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/DtlsClient/Program.cs
+++ b/samples/DtlsClient/Program.cs
@@ -19,8 +19,6 @@ namespace CoAPDevices
             var port = Coap.PortDTLS;
             var identity = new BasicTlsPskIdentity("user", Encoding.UTF8.GetBytes("password"));
 
-            // Create a new client using a DTLS endpoint with the remote host and Identity
-            var client = new CoapClient(new CoapDtlsClientEndPoint(host, port, new ExamplePskDtlsClient(identity)));
             // Create a cancelation token that cancels after 1 minute
             var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(1));
 
@@ -38,24 +36,29 @@ namespace CoAPDevices
 
             try
             {
-                // Create a simple GET request
-                var message = new CoapMessage
+                // Create a new client using a DTLS endpoint with the remote host and Identity
+                using (var client = new CoapClient(new CoapDtlsClientEndPoint(host, port, new ExamplePskDtlsClient(identity))))
                 {
-                    Code = CoapMessageCode.Get,
-                    Type = CoapMessageType.Confirmable,
-                };
+                    // Create a simple GET request
+                    var message = new CoapMessage
+                    {
+                        Code = CoapMessageCode.Get,
+                        Type = CoapMessageType.Confirmable,
+                    };
 
-                // Get the /hello resource from localhost.
-                message.SetUri($"coaps://{host}:{port}/hello");
+                    // Get the /hello resource from localhost.
+                    message.SetUri($"coaps://{host}:{port}/hello");
 
-                Console.WriteLine($"Sending a {message.Code} {message.GetUri().GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped)} request");
-                await client.SendAsync(message, cancellationTokenSource.Token);
+                    Console.WriteLine($"Sending a {message.Code} {message.GetUri().GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped)} request");
+                    await client.SendAsync(message, cancellationTokenSource.Token);
 
-                // Wait for the server to respond.
-                var response = await client.ReceiveAsync(cancellationTokenSource.Token);
+                    // Wait for the server to respond.
+                    var response = await client.ReceiveAsync(cancellationTokenSource.Token);
 
-                // Output our response
-                Console.WriteLine($"Received a response from {response.Endpoint}\n{Encoding.UTF8.GetString(response.Message.Payload)}");
+                    // Output our response
+                    Console.WriteLine($"Received a response from {response.Endpoint}\n{Encoding.UTF8.GetString(response.Message.Payload)}");
+
+                }
             }
             catch (Exception ex)
             {

--- a/samples/DtlsServer/DtlsServer.csproj
+++ b/samples/DtlsServer/DtlsServer.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/DtlsServer/Program.cs
+++ b/samples/DtlsServer/Program.cs
@@ -11,6 +11,7 @@ using Org.BouncyCastle.Tls;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Tls.Crypto.Impl.BC;
 using Org.BouncyCastle.Security;
+using Microsoft.Extensions.Options;
 
 namespace CoAPDevices
 {
@@ -41,7 +42,7 @@ namespace CoAPDevices
             var loggerFactory = LoggerFactory.Create(x => x.AddConsole());
 
             // Create a new Dtls transport factory.
-            var myTransportFactory = new CoapDtlsServerTransportFactory(loggerFactory, new ExampleDtlsServerFactory(), TimeSpan.FromHours(24));
+            var myTransportFactory = new CoapDtlsServerTransportFactory(loggerFactory, new ExampleDtlsServerFactory(), new OptionsWrapper<DtlsServerConfig>(new DtlsServerConfig()));
 
             // Create a new CoapServer using DTLS as it's base transport
             var myServer = new CoapServer(myTransportFactory, loggerFactory.CreateLogger<CoapServer>());

--- a/samples/DtlsServerConnectionId/DtlsServerConnectionId.csproj
+++ b/samples/DtlsServerConnectionId/DtlsServerConnectionId.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/DtlsServerConnectionId/Program.cs
+++ b/samples/DtlsServerConnectionId/Program.cs
@@ -11,6 +11,7 @@ using Org.BouncyCastle.Tls;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Tls.Crypto.Impl.BC;
 using Org.BouncyCastle.Security;
+using Microsoft.Extensions.Options;
 
 namespace CoAPDevices
 {
@@ -41,7 +42,7 @@ namespace CoAPDevices
             var loggerFactory = LoggerFactory.Create(x => x.AddConsole());
 
             // Create a new Dtls transport factory.
-            var myTransportFactory = new CoapDtlsServerTransportFactory(loggerFactory, new ExampleDtlsServerFactory(), TimeSpan.FromHours(24));
+            var myTransportFactory = new CoapDtlsServerTransportFactory(loggerFactory, new ExampleDtlsServerFactory(), new OptionsWrapper<DtlsServerConfig>(new DtlsServerConfig()));
 
             // Create a new CoapServer using DTLS as it's base transport
             var myServer = new CoapServer(myTransportFactory, loggerFactory.CreateLogger<CoapServer>());

--- a/samples/Multicast/Multicast.csproj
+++ b/samples/Multicast/Multicast.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/SimpleClient/SimpleClient.csproj
+++ b/samples/SimpleClient/SimpleClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/SimpleServer/SimpleServer.csproj
+++ b/samples/SimpleServer/SimpleServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/CoAPNet.Dtls/CoAPNet.Dtls.csproj
+++ b/src/CoAPNet.Dtls/CoAPNet.Dtls.csproj
@@ -29,6 +29,7 @@
 
     <ItemGroup>
       <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.0" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/CoAPNet.Dtls/CoAPNet.Dtls.csproj
+++ b/src/CoAPNet.Dtls/CoAPNet.Dtls.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net60</TargetFrameworks>
         <PackageId>NZSmartie.CoAPNet.Dtls</PackageId>
         <LangVersion>latest</LangVersion>
         <Version>0.13.1</Version>

--- a/src/CoAPNet.Dtls/CoAPNet.Dtls.csproj
+++ b/src/CoAPNet.Dtls/CoAPNet.Dtls.csproj
@@ -21,6 +21,7 @@
         <Configurations>Debug;Release;AppVeyor</Configurations>
         <Copyright>Copyright © Roman Vaughan 2017</Copyright>
         <PackageLicenseUrl>https://raw.githubusercontent.com/NZSmartie/CoAP.Net/master/LICENSE</PackageLicenseUrl>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/CoAPNet.Dtls/Server/CoapDtlsConnectionInformation.cs
+++ b/src/CoAPNet.Dtls/Server/CoapDtlsConnectionInformation.cs
@@ -4,8 +4,15 @@ namespace CoAPNet.Dtls.Server
 {
     public class CoapDtlsConnectionInformation : ICoapConnectionInformation
     {
-        public ICoapEndpoint LocalEndpoint { get; set; }
-        public ICoapEndpoint RemoteEndpoint { get; set; }
-        public TlsServer TlsServer { get; set; }
+        public CoapDtlsConnectionInformation(ICoapEndpoint localEndpoint, ICoapEndpoint remoteEndpoint, TlsServer tlsServer)
+        {
+            LocalEndpoint = localEndpoint;
+            RemoteEndpoint = remoteEndpoint;
+            TlsServer = tlsServer;
+        }
+
+        public ICoapEndpoint LocalEndpoint { get; }
+        public ICoapEndpoint RemoteEndpoint { get; }
+        public TlsServer TlsServer { get; }
     }
 }

--- a/src/CoAPNet.Dtls/Server/CoapDtlsServerClientEndPoint.cs
+++ b/src/CoAPNet.Dtls/Server/CoapDtlsServerClientEndPoint.cs
@@ -148,7 +148,7 @@ namespace CoAPNet.Dtls.Server
 
         public DtlsSessionStatistics GetSessionStatistics()
         {
-            return new DtlsSessionStatistics(EndPoint.ToString(), ConnectionInfo, SessionStartTime, LastReceivedTime);
+            return new DtlsSessionStatistics(EndPoint.ToString(), ConnectionInfo, SessionStartTime, LastReceivedTime, ConnectionId != null);
         }
     }
 }

--- a/src/CoAPNet.Dtls/Server/CoapDtlsServerClientEndPoint.cs
+++ b/src/CoAPNet.Dtls/Server/CoapDtlsServerClientEndPoint.cs
@@ -54,7 +54,7 @@ namespace CoAPNet.Dtls.Server
         }
 
         public IPEndPoint EndPoint { get; private set; }
-        public IPEndPoint PendingEndPoint { get; private set; }
+        private IPEndPoint PendingEndPoint { get; set; }
 
         public Uri BaseUri { get; }
         public IReadOnlyDictionary<string, object> ConnectionInfo { get; private set; }

--- a/src/CoAPNet.Dtls/Server/CoapDtlsServerEndPoint.cs
+++ b/src/CoAPNet.Dtls/Server/CoapDtlsServerEndPoint.cs
@@ -14,7 +14,7 @@ namespace CoAPNet.Dtls.Server
         public Uri BaseUri { get; }
         public IPEndPoint IPEndPoint { get; }
 
-        public CoapDtlsServerEndPoint(IPAddress address = null, int port = Coap.PortDTLS)
+        public CoapDtlsServerEndPoint(IPAddress? address = null, int port = Coap.PortDTLS)
         {
             address = address ?? IPAddress.IPv6Any;
 

--- a/src/CoAPNet.Dtls/Server/CoapDtlsServerTransport.cs
+++ b/src/CoAPNet.Dtls/Server/CoapDtlsServerTransport.cs
@@ -337,7 +337,7 @@ namespace CoAPNet.Dtls.Server
                 }
                 catch (TlsTimeoutException timeoutEx)
                 {
-                    _logger.LogWarning(timeoutEx, "Timeout while handling session");
+                    _logger.LogInformation(timeoutEx, "Timeout while handling session");
                 }
                 catch (TlsFatalAlert tlsAlert)
                 {
@@ -349,7 +349,7 @@ namespace CoAPNet.Dtls.Server
                 }
                 finally
                 {
-                    _logger.LogInformation("Connection from {EndPoint} closed", session.EndPoint);
+                    _logger.LogInformation("Connection from {EndPoint} closed after {ElapsedMilliseconds}ms", session.EndPoint, (DateTime.UtcNow - session.SessionStartTime).TotalMilliseconds);
                     _sessions.TryRemove(session.EndPoint, out _);
                 }
             }

--- a/src/CoAPNet.Dtls/Server/CoapDtlsServerTransportFactory.cs
+++ b/src/CoAPNet.Dtls/Server/CoapDtlsServerTransportFactory.cs
@@ -10,7 +10,7 @@ namespace CoAPNet.Dtls.Server
         private readonly ILoggerFactory _loggerFactory;
         private readonly IDtlsServerFactory _tlsServerFactory;
         private readonly DtlsServerConfig _config;
-        private CoapDtlsServerTransport _transport;
+        private CoapDtlsServerTransport? _transport;
 
         /// <param name="loggerFactory">LoggerFactory to use for transport logging</param>
         /// <param name="tlsServerFactory">a <see cref="IDtlsServerFactory"/> that creates the DtlsServer to use.</param>
@@ -34,7 +34,7 @@ namespace CoAPNet.Dtls.Server
             return _transport;
         }
 
-        public DtlsStatistics GetTransportStatistics()
+        public DtlsStatistics? GetTransportStatistics()
         {
             return _transport?.GetStatistics();
         }

--- a/src/CoAPNet.Dtls/Server/CoapDtlsServerTransportFactory.cs
+++ b/src/CoAPNet.Dtls/Server/CoapDtlsServerTransportFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using CoAPNet.Dtls.Server.Statistics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace CoAPNet.Dtls.Server
 {
@@ -8,17 +9,17 @@ namespace CoAPNet.Dtls.Server
     {
         private readonly ILoggerFactory _loggerFactory;
         private readonly IDtlsServerFactory _tlsServerFactory;
-        private readonly TimeSpan _sessionTimeout;
+        private readonly DtlsServerConfig _config;
         private CoapDtlsServerTransport _transport;
 
         /// <param name="loggerFactory">LoggerFactory to use for transport logging</param>
         /// <param name="tlsServerFactory">a <see cref="IDtlsServerFactory"/> that creates the DtlsServer to use.</param>
-        /// <param name="sessionTimeout"> The time without new packets after which a session is assumed to be stale and closed</param>
-        public CoapDtlsServerTransportFactory(ILoggerFactory loggerFactory, IDtlsServerFactory tlsServerFactory, TimeSpan sessionTimeout)
+        /// <param name="config">The configuration for the DTLS server</param>
+        public CoapDtlsServerTransportFactory(ILoggerFactory loggerFactory, IDtlsServerFactory tlsServerFactory, IOptions<DtlsServerConfig> config)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _tlsServerFactory = tlsServerFactory ?? throw new ArgumentNullException(nameof(tlsServerFactory));
-            _sessionTimeout = sessionTimeout;
+            _config = config.Value;
         }
 
         public ICoapTransport Create(ICoapEndpoint endPoint, ICoapHandler handler)
@@ -29,7 +30,7 @@ namespace CoAPNet.Dtls.Server
             if (_transport != null)
                 throw new InvalidOperationException("CoAP transport may only be created once!");
 
-            _transport = new CoapDtlsServerTransport(serverEndpoint, handler, _tlsServerFactory, _loggerFactory, _sessionTimeout);
+            _transport = new CoapDtlsServerTransport(serverEndpoint, handler, _tlsServerFactory, _loggerFactory, _config);
             return _transport;
         }
 

--- a/src/CoAPNet.Dtls/Server/CoapDtlsServerTransportFactory.cs
+++ b/src/CoAPNet.Dtls/Server/CoapDtlsServerTransportFactory.cs
@@ -29,7 +29,7 @@ namespace CoAPNet.Dtls.Server
             if (_transport != null)
                 throw new InvalidOperationException("CoAP transport may only be created once!");
 
-            _transport = new CoapDtlsServerTransport(serverEndpoint, handler, _tlsServerFactory, _loggerFactory.CreateLogger<CoapDtlsServerTransport>(), _sessionTimeout);
+            _transport = new CoapDtlsServerTransport(serverEndpoint, handler, _tlsServerFactory, _loggerFactory, _sessionTimeout);
             return _transport;
         }
 

--- a/src/CoAPNet.Dtls/Server/DtlsServerConfig.cs
+++ b/src/CoAPNet.Dtls/Server/DtlsServerConfig.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace CoAPNet.Dtls.Server
+{
+    /// <summary>
+    /// The configuration for the DTLS server
+    /// </summary>
+    public class DtlsServerConfig
+    {
+        /// <summary>
+        /// Session timeout (inactivity period) after which a session without a connection id is closed.
+        /// </summary>
+        public TimeSpan SessionTimeout { get; set; } = TimeSpan.FromHours(1);
+        /// <summary>
+        /// Session timeout (inactivity period) after which a session with a connection id is closed.
+        /// </summary>
+        public TimeSpan SessionTimeoutWithCid { get; set; } = TimeSpan.FromHours(1);
+    }
+}

--- a/src/CoAPNet.Dtls/Server/DtlsSessionFindResult.cs
+++ b/src/CoAPNet.Dtls/Server/DtlsSessionFindResult.cs
@@ -1,0 +1,11 @@
+﻿namespace CoAPNet.Dtls.Server
+{
+    internal enum DtlsSessionFindResult
+    {
+        NewSession,
+        UnknownCid,
+        FoundByEndPoint,
+        FoundByConnectionId,
+        Invalid
+    }
+}

--- a/src/CoAPNet.Dtls/Server/DtlsSessionStore.cs
+++ b/src/CoAPNet.Dtls/Server/DtlsSessionStore.cs
@@ -1,0 +1,185 @@
+﻿using Microsoft.Extensions.Logging;
+using Org.BouncyCastle.Tls;
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+
+namespace CoAPNet.Dtls.Server
+{
+    internal class DtlsSessionStore
+    {
+        private readonly ILogger<DtlsSessionStore> _logger;
+        private readonly ConcurrentDictionary<IPEndPoint, CoapDtlsServerClientEndPoint> _acceptingSessionsByEp;
+        private readonly ConcurrentDictionary<IPEndPoint, CoapDtlsServerClientEndPoint> _sessionsByEp;
+        private readonly ConcurrentDictionary<byte[], CoapDtlsServerClientEndPoint> _sessionsByCid;
+
+        private int? _connectionIdLength;
+
+        public DtlsSessionStore(ILogger<DtlsSessionStore> logger)
+        {
+            _logger = logger;
+            _acceptingSessionsByEp = new ConcurrentDictionary<IPEndPoint, CoapDtlsServerClientEndPoint>();
+            _sessionsByEp = new ConcurrentDictionary<IPEndPoint, CoapDtlsServerClientEndPoint>();
+            _sessionsByCid = new ConcurrentDictionary<byte[], CoapDtlsServerClientEndPoint>(new ConnectionIdComparer());
+        }
+
+        public IEnumerable<CoapDtlsServerClientEndPoint> GetSessions()
+        {
+            return _sessionsByEp.Values;
+        }
+
+        public DtlsSessionFindResult TryFindSession(UdpReceiveResult data, out CoapDtlsServerClientEndPoint session)
+        {
+            // this is required because there may be packets with a cid before we have been notified of the cid by the session.
+            // once the session is accepted, we just search by cid / endpoint (depending on whether the packet or session use cid or not)
+            if (_acceptingSessionsByEp.TryGetValue(data.RemoteEndPoint, out var cidSessionByEp))
+            {
+                session = cidSessionByEp;
+                return DtlsSessionFindResult.FoundByEndPoint;
+            }
+
+            byte[] cid;
+            try
+            {
+                cid = GetConnectionId(data.Buffer);
+            }
+            catch (Exception ex)
+            {
+                cid = null;
+                _logger.LogError(ex, "Error while getting cid from {EndPoint}", data.RemoteEndPoint);
+            }
+
+            if (cid != null)
+            {
+                if (_sessionsByCid.TryGetValue(cid, out var sessionByCid))
+                {
+                    var endpointChanged = !sessionByCid.EndPoint.Equals(data.RemoteEndPoint);
+                    if (endpointChanged)
+                        _logger.LogDebug("Found session by connection id. {OldEndPoint} -> {NewEndPoint}", sessionByCid.EndPoint, data.RemoteEndPoint);
+
+                    session = sessionByCid;
+                    return endpointChanged ? DtlsSessionFindResult.FoundByConnectionId : DtlsSessionFindResult.FoundByEndPoint;
+                }
+
+                session = null;
+                return DtlsSessionFindResult.UnknownCid;
+            }
+
+            if (_sessionsByEp.TryGetValue(data.RemoteEndPoint, out var sessionByEp))
+            {
+                if (sessionByEp.ConnectionId != null)
+                {
+                    // https://www.rfc-editor.org/rfc/rfc9146.html#section-3-11
+                    // Packet without cid for session with cid.
+                    // This could either be an issue with the client or this endpoint has been reused for another client (NAT issue).
+                    // We drop the packet in this case so the client can try again with another endpoint.
+
+                    _logger.LogInformation("Got packet without cid for session with cid from {EndPoint}. Discarding.", data.RemoteEndPoint);
+                    session = null;
+                    return DtlsSessionFindResult.Invalid;
+                }
+
+                session = sessionByEp;
+                return DtlsSessionFindResult.FoundByEndPoint;
+            }
+
+            session = null;
+            return DtlsSessionFindResult.NewSession;
+        }
+
+        private byte[] GetConnectionId(byte[] packet)
+        {
+            if (!_connectionIdLength.HasValue)
+                return null;
+
+            const int headerCidOffset = 11;
+            var cidLength = _connectionIdLength.Value;
+
+            if (packet.Length >= (headerCidOffset + cidLength) && packet[0] == ContentType.tls12_cid)
+            {
+                var cid = new byte[cidLength];
+                Array.Copy(packet, headerCidOffset, cid, 0, cidLength);
+                return cid;
+            }
+
+            return null;
+        }
+
+        public void Add(CoapDtlsServerClientEndPoint session)
+        {
+            _sessionsByEp.TryAdd(session.EndPoint, session);
+            _acceptingSessionsByEp.TryAdd(session.EndPoint, session);
+        }
+
+        public void NotifySessionAccepted(CoapDtlsServerClientEndPoint session)
+        {
+            if (session.ConnectionId != null)
+            {
+                SetConnectionIdLength(session.ConnectionId.Length);
+                _sessionsByCid.TryAdd(session.ConnectionId, session);
+            }
+            _acceptingSessionsByEp.TryRemove(session.EndPoint, out _);
+        }
+
+        private void SetConnectionIdLength(int sessionCidLength)
+        {
+            if (_connectionIdLength.HasValue)
+            {
+                if (sessionCidLength != _connectionIdLength.Value)
+                    throw new InvalidOperationException("Connection IDs must have constant length!");
+            }
+            else
+            {
+                _connectionIdLength = sessionCidLength;
+            }
+        }
+
+        public void Remove(CoapDtlsServerClientEndPoint session)
+        {
+            _acceptingSessionsByEp.TryRemove(session.EndPoint, out _);
+            _sessionsByEp.TryRemove(session.EndPoint, out _);
+            if (session.ConnectionId != null)
+            {
+                _sessionsByCid.TryRemove(session.ConnectionId, out _);
+            }
+        }
+
+        public void ReplaceSessionEndpoint(IPEndPoint oldEndPoint, IPEndPoint newEndPoint)
+        {
+            _acceptingSessionsByEp.TryRemove(oldEndPoint, out _);
+            if (_sessionsByEp.TryRemove(oldEndPoint, out var session))
+            {
+                if (_sessionsByEp.TryAdd(newEndPoint, session))
+                {
+                    _logger.LogInformation("Replacing endpoint {OldEndPoint} with {NewEndPoint}", oldEndPoint, newEndPoint);
+                }
+                else
+                {
+                    _logger.LogWarning("Couldn't add session because endpoint {NewEndPoint} is already in use!", newEndPoint);
+                    session.Dispose();
+                }
+            }
+        }
+
+        public int GetCount()
+        {
+            return _sessionsByEp.Count;
+        }
+
+        private class ConnectionIdComparer : IEqualityComparer<byte[]>
+        {
+            public bool Equals(byte[] x, byte[] y)
+            {
+                return StructuralComparisons.StructuralEqualityComparer.Equals(x, y);
+            }
+
+            public int GetHashCode(byte[] obj)
+            {
+                return StructuralComparisons.StructuralEqualityComparer.GetHashCode(obj);
+            }
+        }
+    }
+}

--- a/src/CoAPNet.Dtls/Server/DtlsSessionStore.cs
+++ b/src/CoAPNet.Dtls/Server/DtlsSessionStore.cs
@@ -56,10 +56,6 @@ namespace CoAPNet.Dtls.Server
             {
                 if (_sessionsByCid.TryGetValue(cid, out var sessionByCid))
                 {
-                    var endpointChanged = !sessionByCid.EndPoint.Equals(data.RemoteEndPoint);
-                    if (endpointChanged)
-                        _logger.LogDebug("Found session by connection id. {OldEndPoint} -> {NewEndPoint}", sessionByCid.EndPoint, data.RemoteEndPoint);
-
                     session = sessionByCid;
                     return DtlsSessionFindResult.FoundByConnectionId;
                 }
@@ -76,8 +72,9 @@ namespace CoAPNet.Dtls.Server
                     // Packet without cid for session with cid.
                     // This could either be an issue with the client or this endpoint has been reused for another client (NAT issue).
                     // We drop the packet in this case so the client can try again with another endpoint.
+                    // Another solution might be to remove sessions from _sessionsByEp after a connection id is negotiated (but this would require some other changes as well).
 
-                    _logger.LogInformation("Got packet without cid for session with cid from {EndPoint}. Discarding.", data.RemoteEndPoint);
+                    _logger.LogWarning("Got packet without cid for session with cid from {EndPoint}. Discarding.", data.RemoteEndPoint);
                     session = null;
                     return DtlsSessionFindResult.Invalid;
                 }

--- a/src/CoAPNet.Dtls/Server/DtlsSessionStore.cs
+++ b/src/CoAPNet.Dtls/Server/DtlsSessionStore.cs
@@ -31,7 +31,7 @@ namespace CoAPNet.Dtls.Server
             return _sessionsByEp.Values;
         }
 
-        public DtlsSessionFindResult TryFindSession(UdpReceiveResult data, out CoapDtlsServerClientEndPoint session)
+        public DtlsSessionFindResult TryFindSession(UdpReceiveResult data, out CoapDtlsServerClientEndPoint? session)
         {
             // this is required because there may be packets with a cid before we have been notified of the cid by the session.
             // once the session is accepted, we just search by cid / endpoint (depending on whether the packet or session use cid or not)
@@ -41,7 +41,7 @@ namespace CoAPNet.Dtls.Server
                 return DtlsSessionFindResult.FoundByEndPoint;
             }
 
-            byte[] cid;
+            byte[]? cid;
             try
             {
                 cid = GetConnectionId(data.Buffer);
@@ -90,7 +90,7 @@ namespace CoAPNet.Dtls.Server
             return DtlsSessionFindResult.NewSession;
         }
 
-        private byte[] GetConnectionId(byte[] packet)
+        private byte[]? GetConnectionId(byte[] packet)
         {
             if (!_connectionIdLength.HasValue)
                 return null;
@@ -171,7 +171,7 @@ namespace CoAPNet.Dtls.Server
 
         private class ConnectionIdComparer : IEqualityComparer<byte[]>
         {
-            public bool Equals(byte[] x, byte[] y)
+            public bool Equals(byte[]? x, byte[]? y)
             {
                 return StructuralComparisons.StructuralEqualityComparer.Equals(x, y);
             }

--- a/src/CoAPNet.Dtls/Server/DtlsSessionStore.cs
+++ b/src/CoAPNet.Dtls/Server/DtlsSessionStore.cs
@@ -61,7 +61,7 @@ namespace CoAPNet.Dtls.Server
                         _logger.LogDebug("Found session by connection id. {OldEndPoint} -> {NewEndPoint}", sessionByCid.EndPoint, data.RemoteEndPoint);
 
                     session = sessionByCid;
-                    return endpointChanged ? DtlsSessionFindResult.FoundByConnectionId : DtlsSessionFindResult.FoundByEndPoint;
+                    return DtlsSessionFindResult.FoundByConnectionId;
                 }
 
                 session = null;

--- a/src/CoAPNet.Dtls/Server/Statistics/DtlsSessionStatistics.cs
+++ b/src/CoAPNet.Dtls/Server/Statistics/DtlsSessionStatistics.cs
@@ -5,9 +5,17 @@ namespace CoAPNet.Dtls.Server.Statistics
 {
     public class DtlsSessionStatistics
     {
-        public string EndPoint { get; set; }
-        public IReadOnlyDictionary<string, object> ConnectionInfo { get; set; }
-        public DateTime SessionStartTime { get; internal set; }
-        public DateTime LastReceivedTime { get; internal set; }
+        public string EndPoint { get; }
+        public IReadOnlyDictionary<string, object>? ConnectionInfo { get; }
+        public DateTime SessionStartTime { get; }
+        public DateTime LastReceivedTime { get; }
+
+        public DtlsSessionStatistics(string endPoint, IReadOnlyDictionary<string, object>? connectionInfo, DateTime sessionStartTime, DateTime lastReceivedTime)
+        {
+            EndPoint = endPoint;
+            ConnectionInfo = connectionInfo;
+            SessionStartTime = sessionStartTime;
+            LastReceivedTime = lastReceivedTime;
+        }
     }
 }

--- a/src/CoAPNet.Dtls/Server/Statistics/DtlsSessionStatistics.cs
+++ b/src/CoAPNet.Dtls/Server/Statistics/DtlsSessionStatistics.cs
@@ -9,13 +9,15 @@ namespace CoAPNet.Dtls.Server.Statistics
         public IReadOnlyDictionary<string, object>? ConnectionInfo { get; }
         public DateTime SessionStartTime { get; }
         public DateTime LastReceivedTime { get; }
+        public bool HasConnectionId { get; }
 
-        public DtlsSessionStatistics(string endPoint, IReadOnlyDictionary<string, object>? connectionInfo, DateTime sessionStartTime, DateTime lastReceivedTime)
+        public DtlsSessionStatistics(string endPoint, IReadOnlyDictionary<string, object>? connectionInfo, DateTime sessionStartTime, DateTime lastReceivedTime, bool hasConnectionId)
         {
             EndPoint = endPoint;
             ConnectionInfo = connectionInfo;
             SessionStartTime = sessionStartTime;
             LastReceivedTime = lastReceivedTime;
+            HasConnectionId = hasConnectionId;
         }
     }
 }

--- a/src/CoAPNet.Dtls/Server/Statistics/DtlsStatistics.cs
+++ b/src/CoAPNet.Dtls/Server/Statistics/DtlsStatistics.cs
@@ -4,9 +4,21 @@ namespace CoAPNet.Dtls.Server.Statistics
 {
     public class DtlsStatistics
     {
-        public IReadOnlyList<DtlsSessionStatistics> Sessions { get; internal set; }
-        public IDictionary<string, uint> HandshakesByResult { get; internal set; }
-        public IDictionary<string, uint> PacketsReceivedByType { get; internal set; }
-        public uint PacketsSent { get; internal set; }
+        public IReadOnlyList<DtlsSessionStatistics> Sessions { get; }
+        public IDictionary<string, uint> HandshakesByResult { get; }
+        public IDictionary<string, uint> PacketsReceivedByType { get; }
+        public uint PacketsSent { get; }
+
+        public DtlsStatistics(
+            IReadOnlyList<DtlsSessionStatistics> sessions,
+            IDictionary<string, uint> handshakesByResult,
+            IDictionary<string, uint> packetsReceivedByType,
+            uint packetsSent)
+        {
+            Sessions = sessions;
+            HandshakesByResult = handshakesByResult;
+            PacketsReceivedByType = packetsReceivedByType;
+            PacketsSent = packetsSent;
+        }
     }
 }

--- a/tests/CoAPNet.Tests/CoAPNet.Tests.csproj
+++ b/tests/CoAPNet.Tests/CoAPNet.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <LangVersion>latest</LangVersion>
     <DebugType Condition="$(Configuration)=='AppVeyor'">full</DebugType>
     <Configurations>Debug;Release;AppVeyor</Configurations>

--- a/tests/CoApNet.Udp.Tests/CoApNet.Udp.Tests.csproj
+++ b/tests/CoApNet.Udp.Tests/CoApNet.Udp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <LangVersion>latest</LangVersion>
     <DebugType Condition="$(Configuration)=='AppVeyor'">full</DebugType>
     <Configurations>Debug;Release;AppVeyor</Configurations>


### PR DESCRIPTION
Improve logging and statistics
implement connection id closer to spec (especially https://www.rfc-editor.org/rfc/rfc9146.html#section-3-11)
upgrade to net6.0
seperate DTLS session timeout for sessions with/without cid
fix issues when using net6.0 version of BouncyCastle