### PR TITLE
Improve DTLS receive method so idle sessions don't need a running thread

### DIFF
--- a/src/CoAPNet.Dtls/Server/CoapDtlsServerTransport.cs
+++ b/src/CoAPNet.Dtls/Server/CoapDtlsServerTransport.cs
@@ -166,9 +166,7 @@ namespace CoAPNet.Dtls.Server
                         {
                             _logger.LogInformation("New connection from {EndPoint}; Active Sessions: {ActiveSessions}", data.RemoteEndPoint, _sessions.GetCount());
 
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                            Task.Factory.StartNew(() => HandleSession(session), TaskCreationOptions.LongRunning);
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                            _ = Task.Factory.StartNew(() => HandleSession(session), TaskCreationOptions.LongRunning);
                         }
                         catch (Exception ex)
                         {
@@ -294,7 +292,7 @@ namespace CoAPNet.Dtls.Server
                 }
                 finally
                 {
-                    _logger.LogInformation("Connection from {EndPoint} closed after {ElapsedMilliseconds}ms", session.EndPoint, (DateTime.UtcNow - session.SessionStartTime).TotalMilliseconds);
+                    _logger.LogInformation("Connection from {EndPoint} closed after {ElapsedMilliseconds}ms", session.EndPoint, (int)(DateTime.UtcNow - session.SessionStartTime).TotalMilliseconds);
                     _sessions.Remove(session);
                 }
             }

--- a/src/CoAPNet.Dtls/Server/QueueDatagramTransport.cs
+++ b/src/CoAPNet.Dtls/Server/QueueDatagramTransport.cs
@@ -35,6 +35,7 @@ namespace CoAPNet.Dtls.Server
 
         public bool IsClosed { get; private set; }
         public ReaderWriterLockSlim CloseLock { get; } = new ReaderWriterLockSlim();
+        public int QueueCount => _receiveQueue.Count;
 
         public void Close()
         {

--- a/src/CoAPNet.Dtls/Server/QueueDatagramTransport.cs
+++ b/src/CoAPNet.Dtls/Server/QueueDatagramTransport.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using Org.BouncyCastle.Tls;


### PR DESCRIPTION
Use a semaphore for signaling received packets instead of constantly waiting for packets in one thread per session.
This reduces the number of threads dramatically (with 5000 simultaneous sessions: ~5200 -> ~40) which avoids issues with ThreadPool limits and should reduce CPU load and response time significantly.