### PR TITLE
DTLS: fix issue with handshake retransmissions after connection is established

### DIFF
--- a/src/CoAPNet.Dtls/Server/DtlsRecordParser.cs
+++ b/src/CoAPNet.Dtls/Server/DtlsRecordParser.cs
@@ -1,0 +1,39 @@
+﻿using Org.BouncyCastle.Tls;
+using System;
+
+namespace CoAPNet.Dtls.Server
+{
+    internal class DtlsRecordParser
+    {
+        public byte[]? GetConnectionId(byte[] packet, int cidLength)
+        {
+            const int headerCidOffset = 11;
+
+            if (packet.Length >= (headerCidOffset + cidLength) && packet[0] == ContentType.tls12_cid)
+            {
+                var cid = new byte[cidLength];
+                Array.Copy(packet, headerCidOffset, cid, 0, cidLength);
+                return cid;
+            }
+
+            return null;
+        }
+
+        public bool MayBeClientHello(byte[] packet)
+        {
+            const int recordHeaderLength = 13;
+            const int handshakeMessageHeaderLength = 12;
+
+            if (packet.Length < recordHeaderLength + handshakeMessageHeaderLength)
+                return false;
+
+            var contentType = packet[0];
+            if (contentType != ContentType.handshake)
+                return false;
+            if (packet[recordHeaderLength] == HandshakeType.client_hello)
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/src/CoAPNet.Dtls/Server/DtlsSessionFindResult.cs
+++ b/src/CoAPNet.Dtls/Server/DtlsSessionFindResult.cs
@@ -2,10 +2,8 @@
 {
     internal enum DtlsSessionFindResult
     {
-        NewSession,
-        UnknownCid,
+        NotFound,
         FoundByEndPoint,
         FoundByConnectionId,
-        Invalid
     }
 }

--- a/src/CoAPNet.Dtls/Server/DtlsSessionStore.cs
+++ b/src/CoAPNet.Dtls/Server/DtlsSessionStore.cs
@@ -43,24 +43,20 @@ namespace CoAPNet.Dtls.Server
                 }
 
                 session = null;
-                return DtlsSessionFindResult.UnknownCid;
+                return DtlsSessionFindResult.NotFound;
             }
 
             if (_sessionsByEp.TryGetValue(endPoint, out var sessionByEp))
             {
                 if (sessionByEp.ConnectionId != null)
-                {
-                    _logger.LogError("Session has acquired a connection id after it was accepted. Discarding packet.");
-                    session = null;
-                    return DtlsSessionFindResult.Invalid;
-                }
+                    throw new InvalidOperationException("Session has acquired a connection id after it was accepted. Discarding packet.");
 
                 session = sessionByEp;
                 return DtlsSessionFindResult.FoundByEndPoint;
             }
 
             session = null;
-            return DtlsSessionFindResult.NewSession;
+            return DtlsSessionFindResult.NotFound;
         }
 
         public void Add(TSession session)

--- a/tests/CoAPNet.Dtls.Tests/DtlsRecordParserTests.cs
+++ b/tests/CoAPNet.Dtls.Tests/DtlsRecordParserTests.cs
@@ -1,0 +1,36 @@
+﻿using CoAPNet.Dtls.Server;
+using NUnit.Framework;
+using System;
+
+namespace CoAPNet.Dtls.Tests
+{
+    [TestFixture]
+    public class DtlsRecordParserTests
+    {
+        private DtlsRecordParser GetSut()
+        {
+            return new DtlsRecordParser();
+        }
+
+        [TestCase("xjwXKNNEEEq1Y/fAvGGPdA==", "Gf79AAEAAAAAAADGPBco00QQSrVj98C8YY90ACka09mvw1PO5z6+LRkm1OOcunaZ1wUM7MY5rux8cLs71W03XvOkheBKYw==")]
+        [TestCase(null, "Gf79AAEAAAAAAADGPBcoDQ==", Description = "Truncated")]
+        [TestCase(null, "Fv79AAAAAAAAAAIAMxAAACcAAQAAAAAAJwAEdXNlciA4iAxb6rGFbpD936XkpLVVl0sgdZh9uJH/uLroo3hNbg==", Description = "ClientKeyExchange")]
+        public void GetConnectionId(string? expectedCidBase64, string packetBytesBase64)
+        {
+            var sut = GetSut();
+            var expected = expectedCidBase64 == null ? null : Convert.FromBase64String(expectedCidBase64);
+            CollectionAssert.AreEqual(expected, sut.GetConnectionId(Convert.FromBase64String(packetBytesBase64), 16));
+        }
+
+        [TestCase(true, "Fv7/AAAAAAAAAAAAqgEAAJ4AAAAAAAAAnv79fwHWeghJmGi7dnSkKYWcnqfCuArHQa5J0NmXRa9RYMsAAAAQzKzAN8A1zK0AqgCyAJAA/wEAAGQAFgAAABcAAAAFAAUBAAAAAAANADAALggHCAgEAwUDBgMIBAgFCAYICQgKCAsEAQUBBgEEAgUCBgIDAwMBAwICAwIBAgIACgAQAA4AHQAeABcAGAEAAQEBAgALAAIBAAA2AAEA", Description = "Handshake+ClientHello")]
+        [TestCase(false, "Fv7/AAAAAAAAAAAAqg==", Description = "Handshake Truncated")]
+        [TestCase(false, "Fv79AAAAAAAAAAAAXAIAAFAAAAAAAAAAUP79YTGjk7G6hG0Lwr0RaCsXWDpWGwLNAkIlkbKAkvu/bVAAzKwAACgABQAAABcAAAALAAIBAAA2ABEQxjwXKNNEEEq1Y/fAvGGPdP8BAAEA", Description = "Handshake+ServerHello")]
+        [TestCase(false, "Fv79AAAAAAAAAAIAMxAAACcAAQAAAAAAJwAEdXNlciA4iAxb6rGFbpD936XkpLVVl0sgdZh9uJH/uLroo3hNbg==", Description = "Handshake+ClientKeyExchange")]
+        [TestCase(false, "F/79AAEAAAAAAAIAIedv3DQDpEmfPiIHLRRhel7D7mxnai0r1xQF2ItZ5yVYDg==", Description = "ApplicationData")]
+        public void MayBeClientHello(bool expected, string packetBytesBase64)
+        {
+            var sut = GetSut();
+            Assert.AreEqual(expected, sut.MayBeClientHello(Convert.FromBase64String(packetBytesBase64)));
+        }
+    }
+}

--- a/tests/CoAPNet.Dtls.Tests/DtlsSessionStoreTests.cs
+++ b/tests/CoAPNet.Dtls.Tests/DtlsSessionStoreTests.cs
@@ -24,8 +24,8 @@ namespace CoAPNet.Dtls.Tests
             Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, Cid1, out _));
         }
 
-        [Test]
-        public void TryFind_Cid_WithEstablishingCid_FoundByEp()
+        [Test(Description = "packet with cid from session endpoint, establishing session")]
+        public void TryFind_Cid_EstablishingSession_FoundByEp()
         {
             var sessionStore = GetSut();
             var session = new TestSession(Ep1);
@@ -33,8 +33,17 @@ namespace CoAPNet.Dtls.Tests
             Assert.AreEqual(DtlsSessionFindResult.FoundByEndPoint, sessionStore.TryFindSession(Ep1, Cid1, out _));
         }
 
-        [Test]
-        public void TryFind_NoCid_WithEstablishedCid_NotFound()
+        [Test(Description = "packet without cid from session endpoint, establishing session")]
+        public void TryFind_NoCid_EstablishingSession_FoundByEp()
+        {
+            var sessionStore = GetSut();
+            var session = new TestSession(Ep1);
+            sessionStore.Add(session);
+            Assert.AreEqual(DtlsSessionFindResult.FoundByEndPoint, sessionStore.TryFindSession(Ep1, null, out _));
+        }
+
+        [Test(Description = "packet without cid from session endpoint, session with cid")]
+        public void TryFind_NoCid_SessionWithCid_NotFound()
         {
             var sessionStore = GetSut();
             var session = new TestSession(Ep1);
@@ -44,8 +53,8 @@ namespace CoAPNet.Dtls.Tests
             Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, null, out _));
         }
 
-        [Test]
-        public void TryFind_Cid_WithEstablishedCid_FoundByCid()
+        [Test(Description = "packet with cid from different endpoint, session with cid")]
+        public void TryFind_Cid_SessionWithCid_FoundByCid()
         {
             var sessionStore = GetSut();
             var session = new TestSession(Ep1);
@@ -420,7 +429,7 @@ namespace CoAPNet.Dtls.Tests
             session1.ConnectionId = Cid1;
             sessionStore.NotifySessionAccepted(session1);
 
-            // new session with same endpoint
+            // add and accept new session with same endpoint
             Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
             var session2 = new TestSession(Ep1);
             sessionStore.Add(session2);

--- a/tests/CoAPNet.Dtls.Tests/DtlsSessionStoreTests.cs
+++ b/tests/CoAPNet.Dtls.Tests/DtlsSessionStoreTests.cs
@@ -1,9 +1,7 @@
 ﻿using CoAPNet.Dtls.Server;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 
@@ -13,17 +11,17 @@ namespace CoAPNet.Dtls.Tests
     public class DtlsSessionStoreTests
     {
         [Test]
-        public void TryFind_NoCid_NoSession_NewSession()
+        public void TryFind_NoCid_NoSession_NotFound()
         {
             var sessionStore = GetSut();
-            Assert.AreEqual(DtlsSessionFindResult.NewSession, sessionStore.TryFindSession(Ep1, null, out _));
+            Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, null, out _));
         }
 
         [Test]
-        public void TryFind_Cid_NoSession_UnknownCid()
+        public void TryFind_Cid_NoSession_NotFound()
         {
             var sessionStore = GetSut();
-            Assert.AreEqual(DtlsSessionFindResult.UnknownCid, sessionStore.TryFindSession(Ep1, Cid1, out _));
+            Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, Cid1, out _));
         }
 
         [Test]
@@ -36,14 +34,14 @@ namespace CoAPNet.Dtls.Tests
         }
 
         [Test]
-        public void TryFind_NoCid_WithEstablishedCid_NewSession()
+        public void TryFind_NoCid_WithEstablishedCid_NotFound()
         {
             var sessionStore = GetSut();
             var session = new TestSession(Ep1);
             sessionStore.Add(session);
             session.ConnectionId = Cid1;
             sessionStore.NotifySessionAccepted(session);
-            Assert.AreEqual(DtlsSessionFindResult.NewSession, sessionStore.TryFindSession(Ep1, null, out _));
+            Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, null, out _));
         }
 
         [Test]
@@ -361,7 +359,7 @@ namespace CoAPNet.Dtls.Tests
         {
             var sessionStore = GetSut();
 
-            Assert.AreEqual(DtlsSessionFindResult.NewSession, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
+            Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
 
             // new session is added
             var session = new TestSession(Ep1);
@@ -377,7 +375,7 @@ namespace CoAPNet.Dtls.Tests
             // session has been removed (is finished)
             sessionStore.Remove(session);
 
-            Assert.AreEqual(DtlsSessionFindResult.NewSession, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
+            Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
         }
 
         [Test]
@@ -385,7 +383,7 @@ namespace CoAPNet.Dtls.Tests
         {
             var sessionStore = GetSut();
 
-            Assert.AreEqual(DtlsSessionFindResult.NewSession, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
+            Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
 
             // new session is added
             var session = new TestSession(Ep1);
@@ -407,7 +405,7 @@ namespace CoAPNet.Dtls.Tests
             // session has been removed (is finished)
             sessionStore.Remove(session);
 
-            Assert.AreEqual(DtlsSessionFindResult.NewSession, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
+            Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
         }
 
         [Test]
@@ -416,14 +414,14 @@ namespace CoAPNet.Dtls.Tests
             var sessionStore = GetSut();
 
             // add and accept new session with cid
-            Assert.AreEqual(DtlsSessionFindResult.NewSession, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
+            Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
             var session1 = new TestSession(Ep1);
             sessionStore.Add(session1);
             session1.ConnectionId = Cid1;
             sessionStore.NotifySessionAccepted(session1);
 
             // new session with same endpoint
-            Assert.AreEqual(DtlsSessionFindResult.NewSession, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
+            Assert.AreEqual(DtlsSessionFindResult.NotFound, sessionStore.TryFindSession(Ep1, null, out _), "new endpoint => new session");
             var session2 = new TestSession(Ep1);
             sessionStore.Add(session2);
             session2.ConnectionId = Cid2;


### PR DESCRIPTION
Issues may arise when a (retransmitted) handshake message from the client arrives after the connection has been established (after server received the `Finished` message), because currently, that will create a new session that will discard all further communication (typically `ApplicationData` wrapped in `ConnectionId`).

This is somewhat related to #12 because non-`ClientHello` messages should not cause a new session to be created.

Example (view from server):
```
<-- ClientHello [session 1 created]
--> ServerHello, ServerKeyExchange, ServerHelloDone
[retransmit timeout expires]
--> ServerHello, ServerKeyExchange, ServerHelloDone [retransmit]
<-- ClientKeyExchange, ChangeCipherSpec, ConnectionId (Finished)
--> Change Cipher Spec, Finished [Session 1 handshake done]
<-- ClientKeyExchange, ChangeCipherSpec, ConnectionId (Finished) [retransmit][session 2 created]
<-- ConnectionId (Application Data) [gets sent to session 2 and discarded]
<-- ConnectionId (Application Data) [retransmit][gets sent to session 2 and discarded]
[connection fails after timeout]
```